### PR TITLE
Update fly_deployment action to be better

### DIFF
--- a/.github/workflows/fly_deployment.yml
+++ b/.github/workflows/fly_deployment.yml
@@ -10,40 +10,17 @@ on:
       app:
         required: true
         type: string
-      branch:
-        required: true
-        type: string
       environment:
         required: true
         type: string
 
 jobs:
-  production:
-    name: Deploy app to production
-    if: inputs.environment == 'production'
+  deploy:
+    name: Deploy app to Fly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.branch }}
-
       - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - run: flyctl deploy --remote-only -a ${{ inputs.app }} -c vendor/fly-production.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.fly_token }}
-
-  staging:
-    name: Deploy app to staging
-    if: inputs.environment == 'staging'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.branch }}
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - run: flyctl deploy --remote-only -a ${{ inputs.app }} -c vendor/fly-staging.toml
+      - run: flyctl deploy --remote-only --vm-size=performance-2x -a ${{ inputs.app }}-${{ inputs.environment}} -c vendor/fly-${{ inputs.environment }}.toml
         env:
           FLY_API_TOKEN: ${{ secrets.fly_token }}


### PR DESCRIPTION
This gets rid of our separate production/staging specific actions and also decouples it from yetto's app specifically. 

A side benefit of this is that it enforces a naming scheme for applications on Fly and creates a conventional location for the associated `fly.toml` files.