### PR TITLE
Ignoring scripts fails to install platform-specific esbuild packages

### DIFF
--- a/setup-languages/action.yml
+++ b/setup-languages/action.yml
@@ -46,7 +46,7 @@ runs:
       if: ${{ inputs.node == 'true' }}
       shell: bash
       run: |
-        npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
+        npm ci --no-audit --no-progress --prefer-offline
 
     - uses: denoland/setup-deno@v1
       if: ${{ inputs.deno == 'true' }}


### PR DESCRIPTION
I'm attempting to resolve an npm build failure while running `npm ci`, which is thereby causing our test suite to fail.

https://github.com/yettoapp/yetto/actions/runs/5964937468/job/16181260795#step:4:595

After some research, it seems the likely candidate is that we have `--ignore-scripts` in our `npm ci` command, which prevents esbuild specifically from installing platform specific dependencies: https://github.com/evanw/esbuild/issues/1819#issuecomment-1512113327