### PR TITLE
Change up action configurations a smidge

### DIFF
--- a/.github/workflows/fly_deployment.yml
+++ b/.github/workflows/fly_deployment.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   deploy:
     name: Fly
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Start deployment
         id: deployment

--- a/.github/workflows/ruby_security_checks.yml
+++ b/.github/workflows/ruby_security_checks.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bundle-audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +30,7 @@ jobs:
           bundle exec bundle-audit check --update
 
   brakeman: # A static analysis security vulnerability scanner for Ruby on Rails applications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -10,6 +10,14 @@ on:
         required: false
         type: boolean
         default: false
+      postgres_username:
+        required: false
+        type: string
+        default: ""
+      postgres_database_name:
+        required: false
+        type: string
+        default: ""
       node:
         required: false
         type: boolean
@@ -37,6 +45,17 @@ jobs:
   run_with_postgres_and_redis:
     if: ${{ inputs.setup_postgresql_and_redis == true }}
     needs: test
+
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${{ inputs.postgres_username }}
+      RAILS_ENV: test
+      REDIS_URL: redis://localhost:6379/0
+      DATABASE_URL: "postgresql://${{ inputs.postgres_username }}:postgres@localhost:5432/${{ inputs.postgres_database_name }}"
+      RAILS_MASTER_KEY: supersecret
+      SLACK_LOG_URL: https://slack.com/the_log_room
 
     # Service containers to run; note that this is duplicated
     # in sorbet.yml due to a limitation in GitHub Actions

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -33,7 +33,8 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest-m
+    runs-on:
+      labels: ubuntu-latest-m
     outputs:
       setup_postgresql_and_redis: ${{ steps.check_services.outputs.setup_postgresql_and_redis }}
 
@@ -43,8 +44,10 @@ jobs:
           echo "setup_postgresql_and_redis=${{ inputs.setup_postgresql_and_redis }}" >> $GITHUB_OUTPUT
 
   run_with_postgres_and_redis:
-    if: ${{ inputs.setup_postgresql_and_redis == true }}
+    runs-on:
+      labels: ubuntu-latest-m
     needs: test
+    if: ${{ inputs.setup_postgresql_and_redis == true }}
 
     env:
       POSTGRES_HOST: localhost
@@ -84,8 +87,6 @@ jobs:
           --health-cmd "redis-cli ping" --health-interval 10s --health-timeout
           5s --health-retries 5
 
-    runs-on: ubuntu-latest-m
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -99,10 +100,10 @@ jobs:
           system_tests: ${{ inputs.system_tests }}
 
   run_without_services:
-    if: ${{ inputs.setup_postgresql_and_redis == false }}
+    runs-on:
+      labels: ubuntu-latest-m
     needs: test
-
-    runs-on: ubuntu-latest-m
+    if: ${{ inputs.setup_postgresql_and_redis == false }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - id: check_services
         run: |
-          echo "setup_postgresql_and_redis=${{ github.event.inputs.setup_postgresql_and_redis }}" >> $GITHUB_OUTPUT
+          echo "setup_postgresql_and_redis=${{ inputs.setup_postgresql_and_redis }}" >> $GITHUB_OUTPUT
 
   run_with_postgres_and_redis:
     if: inputs.setup_postgresql_and_redis == 'true'

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -1,0 +1,98 @@
+name: Runs a Ruby test suite
+
+on:
+  workflow_call:
+    secrets:
+      gh_token:
+        required: true
+    inputs:
+      setup_postgresql_and_redis:
+        required: false
+        type: boolean
+        default: false
+      node:
+        required: false
+        type: boolean
+        default: false
+      system_tests:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest-m
+    outputs:
+      setup_postgresql_and_redis: ${{ steps.check_services.outputs.setup_postgresql_and_redis }}
+
+    steps:
+      - id: check_services
+        run: |
+          echo "setup_postgresql_and_redis=${{ github.event.inputs.setup_postgresql_and_redis }}" >> $GITHUB_OUTPUT
+
+  run_with_postgres_and_redis:
+    if: inputs.setup_postgresql_and_redis == 'true'
+    needs: test
+
+    # Service containers to run; note that this is duplicated
+    # in sorbet.yml due to a limitation in GitHub Actions
+    # (services can only be defined per job)
+    services:
+      postgres:
+        # Docker Hub image name
+        image: postgres:15 # POSTGRES_VERSION
+        # The postgres container requires the postgres user to be setup with a password in order to start it due to security
+        # reasons. It also can't read from the env var above for some reason
+        env:
+          PGUSER: "${{ env.POSTGRES_USER }}"
+          POSTGRES_USER: "${{ env.POSTGRES_USER }}"
+          POSTGRES_PASSWORD: "${{ env.POSTGRES_PASSWORD }}"
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd 'pg_isready' --health-interval 10s --health-timeout 5s --health-retries 5
+        # Maps tcp port 5432 on service container to the host
+        ports: ["5432:5432"]
+      redis:
+        # Docker Hub image name
+        image: redis:6.2-alpine
+        ports: ["6379:6379"]
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 10s --health-timeout
+          5s --health-retries 5
+
+    runs-on: ubuntu-latest-m
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.gh_token }}
+
+      - uses: yettoapp/actions/run-ruby-tests@main
+        with:
+          github_token: ${{ secrets.gh_token }}
+          node: ${{ inputs.node }}
+          system_tests: ${{ inputs.system_tests }}
+
+  run_without_services:
+    if: inputs.setup_postgresql_and_redis == 'false'
+    needs: test
+
+    runs-on: ubuntu-latest-m
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.gh_token }}
+
+      - uses: yettoapp/actions/run-ruby-tests@main
+        with:
+          github_token: ${{ secrets.gh_token }}
+          node: ${{ inputs.node }}
+          system_tests: ${{ inputs.system_tests }}

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -35,7 +35,7 @@ jobs:
           echo "setup_postgresql_and_redis=${{ inputs.setup_postgresql_and_redis }}" >> $GITHUB_OUTPUT
 
   run_with_postgres_and_redis:
-    if: ${{ inputs.setup_postgresql_and_redis == 'true' }}
+    if: ${{ inputs.setup_postgresql_and_redis == true }}
     needs: test
 
     # Service containers to run; note that this is duplicated
@@ -80,7 +80,7 @@ jobs:
           system_tests: ${{ inputs.system_tests }}
 
   run_without_services:
-    if: ${{ inputs.setup_postgresql_and_redis == 'true' }}
+    if: ${{ inputs.setup_postgresql_and_redis == false }}
     needs: test
 
     runs-on: ubuntu-latest-m

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -48,6 +48,7 @@ jobs:
       labels: ubuntu-latest-m
     needs: test
     if: ${{ inputs.setup_postgresql_and_redis == true }}
+    timeout-minutes: 10
 
     env:
       POSTGRES_HOST: localhost
@@ -104,6 +105,7 @@ jobs:
       labels: ubuntu-latest-m
     needs: test
     if: ${{ inputs.setup_postgresql_and_redis == false }}
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -35,7 +35,7 @@ jobs:
           echo "setup_postgresql_and_redis=${{ inputs.setup_postgresql_and_redis }}" >> $GITHUB_OUTPUT
 
   run_with_postgres_and_redis:
-    if: inputs.setup_postgresql_and_redis == 'true'
+    if: ${{ inputs.setup_postgresql_and_redis == 'true' }}
     needs: test
 
     # Service containers to run; note that this is duplicated
@@ -80,7 +80,7 @@ jobs:
           system_tests: ${{ inputs.system_tests }}
 
   run_without_services:
-    if: inputs.setup_postgresql_and_redis == 'false'
+    if: ${{ inputs.setup_postgresql_and_redis == 'true' }}
     needs: test
 
     runs-on: ubuntu-latest-m

--- a/.github/workflows/test_dockerbuild.yml
+++ b/.github/workflows/test_dockerbuild.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  docker-build:
+  test-build:
     runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_dockerbuild.yml
+++ b/.github/workflows/test_dockerbuild.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-build:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test_dockerbuild.yml
+++ b/.github/workflows/test_dockerbuild.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Build production Dockerfile
         run: flyctl deploy --remote-only --build-only -a yetto-production -c vendor/fly/fly-production.toml
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_PRODUCTION_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.fly_token }}

--- a/.github/workflows/test_dockerbuild.yml
+++ b/.github/workflows/test_dockerbuild.yml
@@ -1,0 +1,29 @@
+name: Test Docker build
+
+on:
+  workflow_call:
+    secrets:
+      gh_token:
+        required: true
+      fly_token:
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest-m
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.gh_token }}
+
+      - uses: yettoapp/actions/setup-fly@main
+
+      - name: Build production Dockerfile
+        run: flyctl deploy --remote-only --build-only -a yetto-production -c vendor/fly/fly-production.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_PRODUCTION_API_TOKEN }}

--- a/run-ruby-tests/action.yml
+++ b/run-ruby-tests/action.yml
@@ -38,12 +38,6 @@ runs:
         sudo apt-get -yqq install libpq-dev
         bundle exec rake db:test:prepare
 
-    - if: ${{ env.DATABASE_URL }}
-      name: Set up the Rails assets
-      shell: bash
-      run: |
-        bundle exec rake assets:precompile
-
     - name: Run tests
       shell: bash
       run: |


### PR DESCRIPTION
I want to keep testing out bigger machine sizes. While doing this, I realized a way to get our Yetto test suite set up in a way that preserves its use of services, while also allowing the workflow to be reused by plugs without services. 