### PR TITLE
Promote Postgresql service to major version 16 and Redis service to major version 7

### DIFF
--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -81,7 +81,7 @@ jobs:
         ports: ["5432:5432"]
       redis:
         # Docker Hub image name
-        image: redis:6.2-alpine
+        image: redis:7-bookworm
         ports: ["6379:6379"]
         # Set health checks to wait until redis has started
         options: >-

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -67,7 +67,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image name
-        image: postgres:15 # POSTGRES_VERSION
+        image: postgres:16-bookworm # POSTGRES_VERSION
         # The postgres container requires the postgres user to be setup with a password in order to start it due to security
         # reasons. It also can't read from the env var above for some reason
         env:


### PR DESCRIPTION
In preparation for migrating to Postgresql@16. 

The Redis change wasn't necessary for that, but in production, we're definitely running version 7.