### PR TITLE
checkout with submodules before publishing

### DIFF
--- a/.github/workflows/ruby_gem_release.yml
+++ b/.github/workflows/ruby_gem_release.yml
@@ -119,6 +119,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up languages
         uses: yettoapp/actions/setup-languages@main


### PR DESCRIPTION
This is causing [mathematical](https://github.com/gjtorikian/mathematical) releases to fail, as they depend on submodules.