### PR TITLE
Enable build for Ruby 3.3

### DIFF
--- a/.github/workflows/ruby_gem_release.yml
+++ b/.github/workflows/ruby_gem_release.yml
@@ -31,8 +31,8 @@ permissions:
   contents: write
   pull-requests: write
 
-# "3.1,3.2" # SUPPORTED_RUBY_VERSIONS
-# "3.2" # LATEST_RUBY_VERSION
+# "3.1,3.2,3.3" # SUPPORTED_RUBY_VERSIONS
+# "3.3" # LATEST_RUBY_VERSION
 
 jobs:
   release:
@@ -201,13 +201,13 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2" # LATEST_RUBY_VERSION
+          ruby-version: "3.3" # LATEST_RUBY_VERSION
 
       - uses: oxidize-rb/actions/cross-gem@v1
         id: cross-gem
         with:
           platform: ${{ matrix.platform }}
-          ruby-versions: "3.1,3.2" # SUPPORTED_RUBY_VERSIONS
+          ruby-versions: "3.1,3.2,3.3" # SUPPORTED_RUBY_VERSIONS
 
       - name: Publish to RubyGems
         env:


### PR DESCRIPTION
https://rubygems.org/gems/commonmarker/versions/1.0.3-arm64-darwin
I noticed that installing commonmarker version 1.0.3, which is built with this action, requires us to build them locally with Ruby 3.3.
It turned out that this action only supports Ruby 3.1 and 3.2 so it doesn't compile it for Ruby 3.3.
This PR adds Ruby 3.3 to the build matrix.