### PR TITLE
Allow for the setting of OTEL env/build args

### DIFF
--- a/.github/workflows/fly_deployment.yml
+++ b/.github/workflows/fly_deployment.yml
@@ -10,6 +10,10 @@ on:
         required: false
       AWS_SECRET_ACCESS_KEY:
         required: false
+      OTEL_EXPORTER_OTLP_HEADERS:
+        required: false
+      OTEL_SERVICE_NAME:
+        required: false
     inputs:
       target:
         required: true
@@ -69,6 +73,8 @@ jobs:
           --vm-size=${{ inputs.target == 'production' && 'performance-2x' || 'shared-cpu-2x' }} \
           --build-arg AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
           --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+          --build-arg OTEL_EXPORTER_OTLP_HEADERS=${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }} \
+          --build-arg OTEL_SERVICE_NAME=${{ secrets.OTEL_SERVICE_NAME }} \
           ${{ inputs.fly_args }} \
           -c vendor/fly/fly-${{ inputs.target }}.toml
         env:


### PR DESCRIPTION
Right now, OpenTelemetry secrets are defined in each app's credentials file. This allows the apps themselves to send data to Honeycomb. However, we also want to start sending machine resource data (CPU usage, memory) to Honeycomb as well (https://github.com/yettoapp/yetto/pull/1108). To do this, we need to install [the OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) on our Docker containers. The secrets are inaccessible to the agent, because they're stored in the app; so we'll store those secrets in the environment, rather the app. 