### PR TITLE
Get beefier test runner machines

### DIFF
--- a/.github/workflows/fly_deployment.yml
+++ b/.github/workflows/fly_deployment.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   deploy:
     name: Fly
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - name: Start deployment
         id: deployment

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   test_setup:
     runs-on:
-      labels: ubuntu-latest-m
+      labels: Ubuntu-TestRunner
     outputs:
       setup_postgresql_and_redis: ${{ steps.check_services.outputs.setup_postgresql_and_redis }}
 
@@ -45,7 +45,7 @@ jobs:
 
   test_with_postgres_and_redis:
     runs-on:
-      labels: ubuntu-latest-m
+      labels: Ubuntu-TestRunner
     needs: test_setup
     if: ${{ inputs.setup_postgresql_and_redis == true }}
     timeout-minutes: 10
@@ -102,7 +102,7 @@ jobs:
 
   test_without_services:
     runs-on:
-      labels: ubuntu-latest-m
+      labels: Ubuntu-TestRunner
     needs: test_setup
     if: ${{ inputs.setup_postgresql_and_redis == false }}
     timeout-minutes: 10

--- a/.github/workflows/test_dockerbuild.yml
+++ b/.github/workflows/test_dockerbuild.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   test-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
As the title says. I doubled our previous test runner (`ubuntu-latest-m`) from 4 cores to 8. I want to see how this affects speed/cost. 