### PR TITLE
Cache Vite assets between builds

### DIFF
--- a/run-ruby-tests/action.yml
+++ b/run-ruby-tests/action.yml
@@ -36,12 +36,29 @@ runs:
       run: |
         bundle exec rake db:create db:schema:load
 
+    - if: ${{ inputs.system_tests == 'true' }}
+      id: cache-assets
+      name: Restore cached Vite assets
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          public/vite-test
+        key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+
     - name: Run tests
       shell: bash
       run: |
         script/ci
       env:
         COVERAGE: "1"
+
+    - name: Cache Vite assets
+      if: ${{ inputs.system_tests == 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          public/vite-test
+        key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
 
     - if: ${{ inputs.system_tests == 'true' }}
       name: Run system tests


### PR DESCRIPTION
I'm trying to find ways to speed up our test workflow, and I noticed we spend about 17 seconds compiling assets on each test run. Every run, we build our JS and CSS. 

The thing is, if we just cached the built assets, and loaded them before the tests runs, Vite will notice that assets don't need to be recompiled, if the contents haven't changed—which they rarely do. 