### PR TITLE
Add plain Ruby test suite

### DIFF
--- a/.github/workflows/rails_test_suite.yml
+++ b/.github/workflows/rails_test_suite.yml
@@ -133,7 +133,7 @@ jobs:
         id: new-vite-cache-key
         shell: bash
         run: |
-            echo "digest=$(bin/rails r 'print ViteRuby.digest')" >> $GITHUB_OUTPUT
+          echo "digest=$(bin/rails r 'print ViteRuby.digest')" >> $GITHUB_OUTPUT
 
       - if: ${{ always() && inputs.system_tests == true && steps.new-vite-cache-key.outputs.digest != steps.restored-vite-cache-key.outputs.digest }}
         name: Cache Vite assets

--- a/.github/workflows/ruby_test_suite.yml
+++ b/.github/workflows/ruby_test_suite.yml
@@ -1,0 +1,40 @@
+---
+name: Runs a Ruby test suite
+
+on:
+  workflow_call:
+    secrets:
+      gh_token:
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on:
+      labels: Ubuntu-TestRunner
+    timeout-minutes: 10
+
+    steps:
+      - if: "contains(github.event.head_commit.message, '[skip test]')"
+        name: Skip test
+        shell: bash
+        run: |
+          echo "Skipping test workflow because commit message contains `[skip test]`"
+          exit 0
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.gh_token }}
+
+      - uses: yettoapp/actions/setup-languages@main
+        with:
+          ruby: true
+
+      - uses: yettoapp/actions/run-ruby-tests@main
+        id: run-tests
+        with:
+          github_token: ${{ secrets.gh_token }}


### PR DESCRIPTION
#20 somewhat inadvertently neutered non-Rails Ruby test suites. Previously, the `run-ruby-tests` composite action used to set up the Ruby language, but this was removed, as the action was rewritten to be far simpler than it was previously. While the Rails reusable action did set up the language, every other Ruby test workflow expected the older composite action; but without the language setup, [the tests would refuse to run](https://github.com/yettoapp/hephaestus/actions/runs/8427495095/job/23078165175).

This PR introduces a reusable workflow to run a Ruby test suite. 