### PR TITLE
disable coverage report

### DIFF
--- a/run-ruby-tests/action.yml
+++ b/run-ruby-tests/action.yml
@@ -31,14 +31,14 @@ runs:
 
         echo "report<<EOF"$'\n'"$coverage_report"$'\n'EOF >> $GITHUB_OUTPUT
 
-    - uses: mshick/add-pr-comment@v2
-      if: "${{ steps.coverage_report.outputs.report != '' }}"
-      with:
-        message: |
-          <!-- type: code_coverage -->
-          ## Code coverage
+    # - uses: mshick/add-pr-comment@v2
+    #   if: "${{ steps.coverage_report.outputs.report != '' }}"
+    #   with:
+    #     message: |
+    #       <!-- type: code_coverage -->
+    #       ## Code coverage
 
-          ```
-           ${{ steps.coverage_report.outputs.report }}
-          ```
-        repo-token: ${{ inputs.github_token }}
+    #       ```
+    #        ${{ steps.coverage_report.outputs.report }}
+    #       ```
+    #     repo-token: ${{ inputs.github_token }}


### PR DESCRIPTION
pains me to do this but I don't think anyone is looking at this—I certainly am not. I'm worried these messages will be ignored when or if we do decide to enable test coverage reporting. note that the report numbers will be available in the CI logs—this just prevents them form being posted as PR comments. 

they're not actionable any time soon and should therefore be removed.