### PR TITLE
Create send-honeycomb-marker action

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ You can find more information about the specific inputs and outputs of each work
 - _run-ruby-tests_: Runs Ruby test suites
 - _run-sorbet-update_: Updates any Sorbet definitions
 - _setup-languages_: Sets up language definitions
+- _send-honeycomb-marker_: Create a Honeycomb Marker of any type in a specified dataset

--- a/send-honeycomb-marker/action.yaml
+++ b/send-honeycomb-marker/action.yaml
@@ -1,0 +1,45 @@
+name: "Send Honeycomb Marker"
+description: "Create a Honeycomb Marker of any type in a specified dataset"
+inputs:
+  honeycombApiKey:
+    description: "The API key to use for the Honeycomb API call"
+    required: true
+  dataset:
+    description: "The Honeycomb Dataset to associate this marker with"
+    required: true
+  type:
+    description: "The type of marker it is (e.g. 'deploy')"
+    required: true
+  message:
+    description: "The message you'd like added to the marker (will be preceeded by the GitHub Actions run ID and job status)"
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Get Pull Request URL
+      shell: bash
+      id: get-pr-url
+      run: |
+        echo 'URL="$(gh api /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq ".[1].html_url")"' >> $GITHUB_OUTPUT
+    - name: Build Payload with jq
+      id: honeycomb-payload
+      shell: bash
+      env:
+        PR_URL: ${{ steps.get-pr-url.outputs.URL }}
+      run: |
+        HONEYCOMB_PAYLOAD="$(jq -nc \
+          --arg prUrl "$PR_URL" \
+          --arg message "[${{ github.run-id }}-${{ job.status }}] ${{ inputs.message }}" \
+          --arg type "${{ inputs.type }}" \
+          '{ \"type\": $type, "\message\": $message, \"url\": $url  }')"
+        echo 'PAYLOAD="$HONEYCOMB_PAYLOAD"' >> $GITHUB_OUTPUT
+    - name: Send Marker to honeycomb
+      shell: bash
+      env:
+        PAYLOAD: ${{ steps.honeycomb-payload.outputs.PAYLOAD }}
+      run: |
+        curl -i -X POST \ 'https://api.honeycomb.io/1/markers/${{ inputs.dataset }}' \
+          -H 'Content-Type: application/json' \
+          -H 'X-Honeycomb-Team: ${{ inputs.honeycombApiKey }}' \
+          -d "$PAYLOAD"
+


### PR DESCRIPTION
While doing some digging this weekend, I found out that Honeycomb lets you [create custom Markers](https://docs.honeycomb.io/investigate/query/customize-results/#markers) (of arbitrary types) that are then displayed on that specific dataset's timeline in charts and can create link-backs to relevant information that might jump start your troubleshooting.

The most obvious use case for these is for marking when a service deploys, so this is a PoC of doing just that.

GitHub Actions "testing" being what it is, I'm gonna have to play with this after it's merged before I think it's ready to put on every deploy action, but I'll figure it out after it merges.