### PR TITLE
Merge, then deploy

### DIFF
--- a/.github/workflows/fly_deployment.yml
+++ b/.github/workflows/fly_deployment.yml
@@ -32,6 +32,15 @@ jobs:
     name: Fly
     runs-on: ubuntu-latest-m
     steps:
+      - name: Merge main branch
+        if: ${{ inputs.forced == false }}
+        uses: everlytic/branch-merge@1.1.1
+        with:
+          github_token: ${{ secrets.gh_token }}
+          source_ref: ${{ github.repository.default_branch }}
+          target_branch: ${{ github.ref }}
+          commit_message_template: "[auto-merge] Merged {source_ref} into target {target_branch}"
+
       - name: Start deployment
         id: deployment
         uses: actions/github-script@v7
@@ -40,7 +49,7 @@ jobs:
           github-token: ${{ secrets.gh_token }}
           script:
             | # FIXME: `required_contexts` are always off, because it seems to conflict with GH actions; https://github.com/yettoapp/yetto/actions/runs/5417564599
-            let forced = ${{ inputs.forced == true }}
+            let forced = ${{ inputs.forced == true }};
             let opts = {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -48,7 +57,7 @@ jobs:
               environment: "${{ inputs.target}}",
               production_environment: ${{ inputs.target == 'production' }},
               transient_environment: ${{ inputs.target == 'staging' }},
-              auto_merge: !forced,
+              auto_merge: false,
               description: "Release deployment",
               required_contexts: []
             };


### PR DESCRIPTION
Sometimes, when you try to deploy, nothing happens.
<img width="636" alt="Screenshot 2024-09-04 at 20 29 57" src="https://github.com/user-attachments/assets/337180e6-5516-432c-8cd2-a6b884fe8f46">


That's because `production` has been updated; when the deployment is being created, it waits for `production` to be merged. [`production` merges](https://github.com/yettoapp/yetto/pull/1420/commits/9b5bd624e2a2b763bfd9ea4bdd6c7f9631d80e8f), but the deploy never happens: it breaks: 

https://github.com/yettoapp/yetto/actions/runs/10711524229/job/29700372925

```
Run actions/github-script@v7
  with:
    github-token: ***
    script: await github.rest.repos.createDeploymentStatus({
    owner: context.repo.owner,
    repo: context.repo.repo,
    deployment_id: ,
    state: "failure",
    log_url: "https://github.com/yettoapp/yetto/actions/runs/10711524229"
  });
  
    debug: false
    user-agent: actions/github-script
    result-encoding: json
    retries: 0
    retry-exempt-status-codes: 400,401,403,404,422
SyntaxError: Unexpected token ','
    at new AsyncFunction (<anonymous>)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16)
    at main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:26)
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35497:1
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35553:3
Error: Unhandled error: SyntaxError: Unexpected token ','
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35556:12)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
```

I've known about this problem for a while, and I'm tired of it. This PR simply does the merge first (as long as it's not being `--force`ed), then continues with the deploy process.