### PR TITLE
Transition to build secrets when deploying

### DIFF
--- a/.github/workflows/test_dockerbuild.yml
+++ b/.github/workflows/test_dockerbuild.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           flyctl deploy --remote-only --build-only \
           -a ${{ inputs.app_name }} \
-          --build-arg AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-          --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+          --build-secret AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
+          --build-secret AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
           ${{ inputs.fly_args }} \
           -c vendor/fly/fly-production.toml \
 


### PR DESCRIPTION
[Build secrets](https://fly.io/docs/apps/build-secrets/) are on my (shortening!!!) list of concerns about the app. None of these AWS keys leak on the GitHub side: they're stored as secrets in the GitHub Action workflow, and are filtered etc out of logs.

But I don't know what happens on the Fly side. If these arguments are provided as `build-args`, maybe they don't treat them as sensitively as they should? Either way, since these key-values are secrets, we should be treating them as such while building the Docker image. 

This action requires a (pending) change in our Dockerfile.