### PR TITLE
Allow repos to be updated via Slack

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Repeat it back
         run: |
           echo "I'm listening..." && \
-          echo "I heard you say update ${{ github.event.inputs.action }} (to ${{ github.event.inputs.value }}"
+          echo "I heard you say update ${{ github.event.inputs.action }} (to ${{ github.event.inputs.value }})"
 
       - name: Update the app
         run: |
@@ -75,7 +75,7 @@ jobs:
           if [ -f .ruby-version ]; then
             echo ${{ github.event.inputs.value }} > .ruby-version
           elif [ "$GITHUB_REPOSITORY" == "yettoapp/images" ]; then
-            find . -type f -exec sed -i '' "s/RUBY_VERSION=[0-9]*\.[0-9]*\.[0-9]*/RUBY_VERSION=${{ github.event.inputs.value }}/g" {} +
+           find . -type f -name 'Dockerfile' -exec perl -pi -w -e 's/RUBY_VERSION=.+/RUBY_VERSION=${{ github.event.inputs.value }}/g;' {} +
           else
             echo "I have no idea what you want me to do with Ruby."
             exit 1;

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -68,9 +68,5 @@ jobs:
           labels: update
           branch: "update-hephaestus"
 
-      - name: Update Hephaestus
-        if: ${{ github.event.inputs.action == 'hephaestus' }}
-        run: |
-          bundle update hephaestus
-          HEPHAESTUS_VERSION="bundle show hephaestus | grep -oE 'hephaestus-[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'"
-          echo "HEPHAESTUS_VERSION=${HEPHAESTUS_VERSION}" >> $GITHUB_ENV
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Update the app
         run: |
           if [ "${{ github.event.inputs.action }}" == "ruby" ]; then
-            echo "action=ruby" >> $GITHUB_ENV
+            echo "UPDATE_ACTION=ruby" >> $GITHUB_ENV
           elif [ "${{ github.event.inputs.action }}" == "hephaestus" ]; then
-            echo "action=hephaestus" >> $GITHUB_ENV
+            echo "UPDATE_ACTION=hephaestus" >> $GITHUB_ENV
           else
             echo "I don't know what '${{ github.event.inputs.action }}' means."
             exit 0;
@@ -47,3 +47,42 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           token: ${{ secrets.GH_SISYPHUS_YETTO_REPO_TOKEN }}
+          path: ${{ github.event.inputs.repo }}
+
+      - name: cd into project directory
+        if: ${{ github.event.inputs.action == 'hephaestus' || github.event.inputs.action == 'ruby' }}
+        run: cd ${{ github.event.inputs.repo }}
+
+      - uses: yettoapp/actions/setup-languages@main
+        if: ${{ github.event.inputs.action == 'hephaestus' }}
+        with:
+          ruby: true
+
+      - name: Update Hephaestus
+        if: ${{ github.event.inputs.action == 'hephaestus' }}
+        run: bundle update hephaestus
+
+      - name: Update Hephaestus
+        if: ${{ github.event.inputs.action == 'hephaestus' }}
+        run: |
+          bundle update hephaestus
+          HEPHAESTUS_VERSION="bundle show hephaestus | grep -oE 'hephaestus-[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'"
+          echo "HEPHAESTUS_VERSION=${HEPHAESTUS_VERSION}" >> $GITHUB_ENV
+
+      - name: Create Hephaestus Pull Request
+        id: cpr
+        if: ${{ github.event.inputs.action == 'hephaestus' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: "Gemfile.lock"
+          commit-message: "Update Hephaestus to v${{ env.HEPHAESTUS_VERSION }}"
+          title: "Update Hephaestus to v${{ env.HEPHAESTUS_VERSION }}"
+          body: >
+            This is an automated PR to update Hephaestus to v${{ env.HEPHAESTUS_VERSION }}.<br/><br/>
+            Due to security considerations, PRs created by GitHub Actions cannot
+            be merged automatically. Please review the changes and merge the PR.<br/><br/>
+            If you require the test suites to run, you can close the PR and reopen it to trigger
+            those workflows.
+          delete-branch: true
+          labels: update
+          branch: "update-hephaestus"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -52,7 +52,7 @@ jobs:
           echo "HEPHAESTUS_VERSION=${HEPHAESTUS_VERSION}" >> $GITHUB_ENV
 
       - name: Create Hephaestus Pull Request
-        id: cpr
+        id: hephaestus-pr
         if: ${{ github.event.inputs.action == 'hephaestus' }}
         uses: peter-evans/create-pull-request@v7
         with:
@@ -68,3 +68,29 @@ jobs:
           delete-branch: true
           labels: update
           branch: "update-hephaestus"
+
+      - name: Set Ruby version
+        if: ${{ github.event.inputs.action == 'ruby' }}
+        run: |
+          if [ -f .ruby-version ]; then
+            echo ${{ github.event.inputs.value }} > .ruby-version
+          else
+            echo "RUBY_VERSION=3.0.2" >> $GITHUB_ENV
+          fi
+
+      - name: Create Ruby Pull Request
+        id: ruby-pr
+        if: ${{ github.event.inputs.action == 'ruby' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Update Ruby to v${{ github.event.inputs.value }}"
+          title: "Update Ruby to v${{ github.event.inputs.value }}"
+          body: >
+            This is an automated PR to update Ruby to v${{ github.event.inputs.value }}.<br/><br/>
+            Due to security considerations, PRs created by GitHub Actions cannot
+            be merged automatically. Please review the changes and merge the PR.<br/><br/>
+            If you require the test suites to run, you can close the PR and reopen it to trigger
+            those workflows.
+          delete-branch: true
+          labels: update
+          branch: "update-ruby"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -68,6 +68,3 @@ jobs:
           delete-branch: true
           labels: update
           branch: "update-hephaestus"
-
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Update Hephaestus
         if: ${{ github.event.inputs.action == 'hephaestus' }}
         run: |
+          bundle config unset deployment
           bundle update hephaestus
           HEPHAESTUS_VERSION="bundle show hephaestus | grep -oE 'hephaestus-[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'"
           echo "HEPHAESTUS_VERSION=${HEPHAESTUS_VERSION}" >> $GITHUB_ENV

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -74,8 +74,11 @@ jobs:
         run: |
           if [ -f .ruby-version ]; then
             echo ${{ github.event.inputs.value }} > .ruby-version
+          elif [ "$GITHUB_REPOSITORY" == "yettoapp/images" ]; then
+            find . -type f -exec sed -i '' "s/RUBY_VERSION=[0-9]*\.[0-9]*\.[0-9]*/RUBY_VERSION=${{ github.event.inputs.value }}/g" {} +
           else
-            echo "RUBY_VERSION=3.0.2" >> $GITHUB_ENV
+            echo "I have no idea what you want me to do with Ruby."
+            exit 1;
           fi
 
       - name: Create Ruby Pull Request

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Repeat it back
         run: |
           echo "I'm listening..." && \
-          echo "I heard you say update ${{ github.event.inputs.action }} in ${{ github.event.inputs.repo }} (to ${{ github.event.inputs.value }}"
+          echo "I heard you say update ${{ github.event.inputs.action }} (to ${{ github.event.inputs.value }}"
 
       - name: Update the app
         run: |

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -25,7 +25,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Hear it?
+      - name: Repeat it back
         run: |
           echo "I'm listening..." && \
           echo "I heard you say update ${{ github.event.inputs.action }} in ${{ github.event.inputs.repo }} (to ${{ github.event.inputs.value }}"
+
+      - name: Update the app
+        run: |
+          if [ "${{ github.event.inputs.action }}" == "ruby" ]; then
+            echo "action=ruby" >> $GITHUB_ENV
+          elif [ "${{ github.event.inputs.action }}" == "hephaestus" ]; then
+            echo "action=hephaestus" >> $GITHUB_ENV
+          else
+            echo "I don't know what '${{ github.event.inputs.action }}' means."
+            exit 0;
+          fi
+
+      - name: Check out project repository
+        if: ${{ github.event.inputs.action == 'hephaestus' || github.event.inputs.action == 'ruby' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.repo }}
+          token: ${{ secrets.GH_SISYPHUS_YETTO_REPO_TOKEN }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Hear it?
         run: |
-          echo "I'm listening..."
-          I heard you say update ${{ github.event.inputs.action }} in ${{ github.event.inputs.repo }} (to ${{ github.event.inputs.value }}
+          echo "I'm listening..." && \
+          echo "I heard you say update ${{ github.event.inputs.action }} in ${{ github.event.inputs.repo }} (to ${{ github.event.inputs.value }}"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,16 +1,13 @@
-name: Update apps
+name: Update repository
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       action:
         required: true
         type: string
       value:
         required: false
-        type: string
-      repo:
-        required: true
         type: string
 
 permissions:
@@ -41,26 +38,10 @@ jobs:
             exit 0;
           fi
 
-      - name: Check out project repository
-        if: ${{ github.event.inputs.action == 'hephaestus' || github.event.inputs.action == 'ruby' }}
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.inputs.repo }}
-          token: ${{ secrets.GH_SISYPHUS_YETTO_REPO_TOKEN }}
-          path: ${{ github.event.inputs.repo }}
-
-      - name: cd into project directory
-        if: ${{ github.event.inputs.action == 'hephaestus' || github.event.inputs.action == 'ruby' }}
-        run: cd ${{ github.event.inputs.repo }}
-
       - uses: yettoapp/actions/setup-languages@main
         if: ${{ github.event.inputs.action == 'hephaestus' }}
         with:
           ruby: true
-
-      - name: Update Hephaestus
-        if: ${{ github.event.inputs.action == 'hephaestus' }}
-        run: bundle update hephaestus
 
       - name: Update Hephaestus
         if: ${{ github.event.inputs.action == 'hephaestus' }}
@@ -86,3 +67,10 @@ jobs:
           delete-branch: true
           labels: update
           branch: "update-hephaestus"
+
+      - name: Update Hephaestus
+        if: ${{ github.event.inputs.action == 'hephaestus' }}
+        run: |
+          bundle update hephaestus
+          HEPHAESTUS_VERSION="bundle show hephaestus | grep -oE 'hephaestus-[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'"
+          echo "HEPHAESTUS_VERSION=${HEPHAESTUS_VERSION}" >> $GITHUB_ENV

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           bundle config unset deployment
           bundle update hephaestus
-          HEPHAESTUS_VERSION="bundle show hephaestus | grep -oE 'hephaestus-[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'"
+          HEPHAESTUS_VERSION="$(bundle show hephaestus | grep -oE 'hephaestus-[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
           echo "HEPHAESTUS_VERSION=${HEPHAESTUS_VERSION}" >> $GITHUB_ENV
 
       - name: Create Hephaestus Pull Request


### PR DESCRIPTION
This is the "backend" for https://github.com/yettoapp/sisyphus/pull/59.

You can try out various combinations in Slack:

```
# updates yettoapp/yetto
!update ruby for yetto to 3.3.6
# updated yettoapp/images
!update ruby for images to 3.3.6
# updates all the plugs
!update ruby for every-plug to 3.3.6
# updates just one plug
!update ruby for plug-github to 3.3.6

# updates all the plugs
!update Hephaestus for every-plug
# updates just one plug
!update ruby for plug-zendesk to 3.3.6
```

Crucially, while this action changes files and opens PRs, a human is needed for the final PR merge. As well, as noisy as this system is, it will simplify operations immensely. Ruby 3.4 is coming on Dec 25, and with each release the language just gets better and with a reduced memory footprint.