### PR TITLE
Skip licenses updating tests

### DIFF
--- a/.github/workflows/run_license_verify.yml
+++ b/.github/workflows/run_license_verify.yml
@@ -24,6 +24,10 @@ permissions:
 jobs:
   licensed:
     runs-on: ubuntu-latest-m
+
+    # always skip
+    if: true
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
I think the usefulness of the license checking workflow has come to an end. It's a pain point for me when updating plugs because each repo maintains its own list. It's not clear what the usefulness of this up-to-date bookkeeping is.

Every plug (and the main Yetto app) will keep its `script/licenses` script, which directly calls [the script in this repo](https://github.com/yettoapp/actions/blob/789c00edcabc7aba29f91de12eb478b381ed4b77/script/licenses), so one-off licenses generations and updates can still occur. They just won't occur on every single change now. 