### PR TITLE
Store Vite artifacts for quicker Docker build

### DIFF
--- a/.github/workflows/fly_deployment.yml
+++ b/.github/workflows/fly_deployment.yml
@@ -76,6 +76,14 @@ jobs:
             });
             return deployment.data.id
 
+      - name: Restore Vite dependencies cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules/.vite
+          key: vite-deps-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/vite.config.*') }}
+          restore-keys: |
+            vite-deps-${{ runner.os }}-
+
       - uses: yettoapp/actions/setup-fly@main
 
       # note that build secrets are defined on a per app basis, but due
@@ -97,6 +105,14 @@ jobs:
           -c vendor/fly/fly-${{ inputs.target }}.toml
         env:
           FLY_API_TOKEN: ${{ secrets.fly_token }}
+
+      - name: Cache Vite dependencies
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.vite
+          key: vite-deps-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/vite.config.*') }}
+          restore-keys: |
+            vite-deps-${{ runner.os }}-
 
       - name: update deployment status
         uses: actions/github-script@v8


### PR DESCRIPTION
On every deployment, the Docker build rebuilds assets, even if the assets haven't changed. This process takes (wastes) about 30s on every deploy.

Instead, this PR attempts to add a cache to the deployment process; on every subsequent build, the cache will be restored. We can't skip the assets compilation step, but we might be able to avoid it if the files haven't changed. This should make deployments and iterative changes quicker.