### PR TITLE
Have `--forced` run deployments immediately

### DIFF
--- a/.github/workflows/fly_deployment.yml
+++ b/.github/workflows/fly_deployment.yml
@@ -78,6 +78,13 @@ jobs:
 
       - uses: yettoapp/actions/setup-fly@main
 
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ inputs.forced }}" == "true" ]]; then
+            echo "DEPLOY_FLAG=--deploy immediate" >> $GITHUB_ENV
+          fi
+
       # note that build secrets are defined on a per app basis, but due
       # to a limitation in GitHub Actions, we can't define them in the
       # workflow_call inputs. if these are not set, they harmlessly default to `""`
@@ -85,6 +92,7 @@ jobs:
         timeout-minutes: 10
         run: |
           flyctl deploy --remote-only \
+          ${{ env.DEPLOY_FLAG }}
           --build-arg CACHEBUST=$(date +%s) \
           --build-arg GIT_SHA=${{ github.sha }} \
           --build-arg REGISTRY=ghcr.io/ \


### PR DESCRIPTION
Did you know there's a [`--force`](https://github.com/yettoapp/sisyphus/blob/7e8791f005f58e270677da8a6179ca2b285d1d67/sisyphus/listeners/deploy.py#L90) flag for deployments?

Currently it...does nothing. This PR sets it up such that `--force` overrides our `blue-green` deployment strategy in favor of an `immediate` one, which should make it quicker to deploy changes that need to go out ASAP.